### PR TITLE
Add GPU sizing guidance and grocery demand-forecasting NN example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,94 @@
 # Bitsproject
-Dummy Project for demonstrating CI/CD Pipeline
+
+## Custom Neural Network Use Case: Grocery Chain Demand Forecasting
+
+A realistic organization-level use case is a **national grocery retailer** forecasting SKU-level demand per store for the next day/week.
+
+### Why a custom neural network?
+Classical models (ARIMA/Prophet/XGBoost alone) can struggle to jointly model:
+- Store attributes (size, region, demographics)
+- Product attributes (category, perishability, promotion sensitivity)
+- Temporal signals (recent demand, day-of-week, seasonality)
+- Nonlinear interactions (promotion effect differs by store/product)
+
+A custom neural network can combine these inputs through dedicated feature towers and a shared prediction head.
+
+---
+
+## GPU Requirements During Training
+
+When estimating GPU requirements, plan for these memory components:
+
+1. **Model parameters** (weights)
+2. **Gradients** (roughly similar size as weights)
+3. **Optimizer states** (Adam/AdamW often ~2x parameter memory)
+4. **Activations** (depends heavily on batch size and network depth)
+5. **Framework overhead + fragmentation** (safety margin)
+
+A practical rough formula used in this repo script:
+
+- `Total VRAM ≈ (params + grads + optimizer + activations) * safety_factor`
+
+### Quick sizing heuristics
+- Small tabular model (few million params): 8–16 GB GPU usually enough.
+- Medium multimodal model (10M–100M params): 24–48 GB often needed.
+- Large models: multi-GPU with data/model parallelism.
+
+Use mixed precision (FP16/BF16), gradient checkpointing, and gradient accumulation if memory is tight.
+
+---
+
+## Main Bottlenecks (Real Life)
+
+1. **Data quality & feature freshness**
+   - Inconsistent POS data, stockouts mislabeled as low demand, delayed promotion feeds.
+2. **Training throughput**
+   - Slow dataloader or feature joins can leave GPU idle.
+3. **Concept drift**
+   - Demand behavior changes (holidays, inflation, local events).
+4. **Latency at inference**
+   - Store planning systems may require predictions within strict SLA windows.
+5. **MLOps governance**
+   - Versioning, rollback, explainability, and audit trails for business trust.
+
+---
+
+## How to Take It to Production
+
+1. **Data & feature pipeline**
+   - Build reproducible offline/online feature definitions.
+   - Add validation checks (nulls, ranges, drift).
+2. **Training pipeline**
+   - Containerized training job with experiment tracking.
+   - Save metrics and artifacts in model registry.
+3. **Validation gate**
+   - Promote only if model beats baseline (MAPE/WAPE/stockout metrics).
+4. **Serving pattern**
+   - Batch inference nightly for replenishment planning.
+   - Optional realtime endpoint for dynamic repricing decisions.
+5. **Progressive rollout**
+   - Shadow mode → limited region rollout → full rollout.
+6. **Monitoring**
+   - Data drift, prediction drift, business KPIs, SLA latency.
+7. **Retraining strategy**
+   - Scheduled retraining (weekly) + event-triggered retraining.
+
+---
+
+## Code
+
+See:
+
+- `custom_nn_gpu_prod_use_case.py`
+
+The script includes:
+- A GPU memory estimation helper
+- A custom PyTorch demand network
+- Mixed-precision training loop
+- Production handoff placeholder for export/serving
+
+Run:
+
+```bash
+python custom_nn_gpu_prod_use_case.py
+```

--- a/custom_nn_gpu_prod_use_case.py
+++ b/custom_nn_gpu_prod_use_case.py
@@ -1,0 +1,191 @@
+"""
+Custom neural network use case:
+Demand forecasting for a grocery retail chain.
+
+This script demonstrates:
+- GPU requirement estimation utilities
+- A custom PyTorch model (tabular + temporal features)
+- Training loop with mixed precision
+- Bottleneck-aware production notes embedded as comments
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+
+
+@dataclass
+class GpuEstimate:
+    params_millions: float
+    model_memory_gb: float
+    activation_memory_gb: float
+    optimizer_memory_gb: float
+    total_estimated_gb: float
+
+
+def estimate_training_gpu_memory(
+    parameter_count: int,
+    batch_size: int,
+    activation_elements_per_sample: int,
+    bytes_per_element: int = 2,
+    optimizer_multiplier: float = 2.0,
+    gradient_multiplier: float = 1.0,
+    safety_factor: float = 1.3,
+) -> GpuEstimate:
+    """
+    Rough training VRAM estimate.
+
+    Assumptions for mixed precision training:
+    - Weights in fp16/bf16 + master weights/optimizer states in fp32
+    - Optimizer states are roughly 2x parameter memory for Adam-like optimizers
+    - Gradient memory ~ parameter memory
+    """
+    params_mem = parameter_count * bytes_per_element
+    activations_mem = batch_size * activation_elements_per_sample * bytes_per_element
+    optimizer_mem = params_mem * optimizer_multiplier
+    grads_mem = params_mem * gradient_multiplier
+
+    total = (params_mem + activations_mem + optimizer_mem + grads_mem) * safety_factor
+
+    gb = 1024**3
+    return GpuEstimate(
+        params_millions=parameter_count / 1e6,
+        model_memory_gb=params_mem / gb,
+        activation_memory_gb=activations_mem / gb,
+        optimizer_memory_gb=optimizer_mem / gb,
+        total_estimated_gb=total / gb,
+    )
+
+
+class GroceryDemandDataset(Dataset):
+    """
+    Example dataset shape:
+    - static features (store and product attributes)
+    - sequence features (previous daily sales)
+    - target: next-day sales quantity
+    """
+
+    def __init__(self, n_samples: int = 5000, static_dim: int = 32, seq_len: int = 30):
+        self.static = torch.randn(n_samples, static_dim)
+        base = torch.randn(n_samples, seq_len)
+        trend = torch.linspace(0.0, 1.0, steps=seq_len).unsqueeze(0)
+        self.sequence = base + trend
+
+        # Synthetic target with nonlinear interaction
+        self.target = (
+            0.4 * self.static[:, :8].sum(dim=1)
+            + 0.8 * self.sequence[:, -7:].mean(dim=1)
+            + torch.sin(self.sequence[:, -1])
+            + 0.1 * torch.randn(n_samples)
+        ).unsqueeze(1)
+
+    def __len__(self) -> int:
+        return self.static.shape[0]
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.static[idx], self.sequence[idx], self.target[idx]
+
+
+class DemandNet(nn.Module):
+    """Custom NN combining MLP (static) + temporal encoder (sequence)."""
+
+    def __init__(self, static_dim: int = 32, seq_len: int = 30, hidden: int = 64):
+        super().__init__()
+        self.static_tower = nn.Sequential(
+            nn.Linear(static_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+
+        self.seq_tower = nn.Sequential(
+            nn.Linear(seq_len, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+
+        self.head = nn.Sequential(
+            nn.Linear(hidden * 2, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, 1),
+        )
+
+    def forward(self, static_x: torch.Tensor, seq_x: torch.Tensor) -> torch.Tensor:
+        s = self.static_tower(static_x)
+        t = self.seq_tower(seq_x)
+        return self.head(torch.cat([s, t], dim=1))
+
+
+def train_one_epoch(model, loader, optimizer, device, scaler):
+    model.train()
+    criterion = nn.MSELoss()
+    running = 0.0
+
+    for static_x, seq_x, y in loader:
+        static_x = static_x.to(device)
+        seq_x = seq_x.to(device)
+        y = y.to(device)
+
+        optimizer.zero_grad(set_to_none=True)
+
+        with torch.autocast(device_type=device.type, dtype=torch.float16, enabled=device.type == "cuda"):
+            pred = model(static_x, seq_x)
+            loss = criterion(pred, y)
+
+        scaler.scale(loss).backward()
+        scaler.step(optimizer)
+        scaler.update()
+
+        running += loss.item() * static_x.size(0)
+
+    return running / len(loader.dataset)
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    model = DemandNet(static_dim=32, seq_len=30, hidden=128).to(device)
+
+    parameter_count = sum(p.numel() for p in model.parameters())
+    estimate = estimate_training_gpu_memory(
+        parameter_count=parameter_count,
+        batch_size=512,
+        activation_elements_per_sample=128 * 8,
+    )
+
+    print("\n=== GPU Estimate (rough) ===")
+    print(f"Params (M): {estimate.params_millions:.3f}")
+    print(f"Model memory (GB): {estimate.model_memory_gb:.4f}")
+    print(f"Activation memory (GB): {estimate.activation_memory_gb:.4f}")
+    print(f"Optimizer memory (GB): {estimate.optimizer_memory_gb:.4f}")
+    print(f"Total estimate (GB): {estimate.total_estimated_gb:.4f}")
+
+    dataset = GroceryDemandDataset(n_samples=12000, static_dim=32, seq_len=30)
+    loader = DataLoader(dataset, batch_size=512, shuffle=True, num_workers=0)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
+    scaler = torch.cuda.amp.GradScaler(enabled=device.type == "cuda")
+
+    for epoch in range(1, 6):
+        loss = train_one_epoch(model, loader, optimizer, device, scaler)
+        print(f"Epoch {epoch:02d} | train_loss={loss:.4f}")
+
+    # Production-ready model export placeholder
+    model.eval()
+    dummy_static = torch.randn(1, 32, device=device)
+    dummy_seq = torch.randn(1, 30, device=device)
+    with torch.no_grad():
+        _ = model(dummy_static, dummy_seq)
+
+    print("Training complete. Next steps: validation, calibration, model registry, A/B rollout.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide practical guidance for estimating GPU VRAM needs and trade-offs when training neural networks on tabular + temporal retail data. 
- Demonstrate a realistic org-level use case (grocery chain SKU/store demand forecasting) and outline productionization steps and common bottlenecks.

### Description
- Add `README.md` content with GPU sizing heuristics, training memory component breakdown, common bottlenecks, and a production rollout checklist. 
- Add `custom_nn_gpu_prod_use_case.py` which implements a GPU estimator (`GpuEstimate`, `estimate_training_gpu_memory`), a synthetic `GroceryDemandDataset`, and a custom PyTorch model `DemandNet` that combines static and sequence towers. 
- Include a mixed-precision training loop using `torch.cuda.amp.GradScaler`, training harness (`train_one_epoch` / `main`), an example `DataLoader` setup, and a lightweight production handoff placeholder for model export/inference.

### Testing
- Compiled the new script with `python -m py_compile custom_nn_gpu_prod_use_case.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d4d5204c8324ae9107b792326319)